### PR TITLE
Exec and show

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,3 +74,4 @@ Daniel Oliveira     drdo at drdo.eu
 Panji Kusuma        epanji at gmail dot com
 Andrin Bertschi     hi at abertschi dot ch
 Spenser Max Truex   web ate spensertruex.com
+Max-Gerd Retzlaff   m.retzlaff at gmx.net

--- a/bindings.lisp
+++ b/bindings.lisp
@@ -89,6 +89,7 @@ is a tile group.")
   (kbd "a")   "time"
   (kbd "C-a") "time"
   (kbd "!")   "exec"
+  (kbd "M-!") "exec&show"
   (kbd "C-g") "abort"
   *escape-fake-key* "send-escape"
   (kbd ";")   "colon"

--- a/user.lisp
+++ b/user.lisp
@@ -167,7 +167,13 @@ such a case, kill the shell command to resume StumpWM."
       (run-prog-collect-output *shell-program* "-c" cmd)
       (run-prog *shell-program* :args (list "-c" cmd) :wait nil)))
 
+(defcommand run-shell-command-and-show-output (cmd) ((:shell "/bin/sh -c "))
+  "Call run-shell-command, collect the output and show as message"
+  (message (run-shell-command cmd t)))
+
 (defcommand-alias exec run-shell-command)
+
+(defcommand-alias exec&show run-shell-command-and-show-output)
 
 (defcommand eval-line (cmd) ((:rest "Eval: "))
   "Evaluate the s-expression and display the result(s)."

--- a/user.lisp
+++ b/user.lisp
@@ -158,13 +158,15 @@ with base. Automagically update the cache."
                                 :end2 (length base)))) 
                  (path-cache-programs *path-cache*)))
 
-(defcommand run-shell-command (cmd &optional collect-output-p) ((:shell "/bin/sh -c "))
+(defcommand run-shell-command (cmd &optional collect-output-p (timeout 30)) ((:shell "/bin/sh -c "))
   "Run the specified shell command. If @var{collect-output-p} is @code{T}
-then run the command synchonously and collect the output. Be
-careful. If the shell command doesn't return, it will hang StumpWM. In
-such a case, kill the shell command to resume StumpWM."
+then run the command synchonously with a timeout and collect the output.
+After TIMEOUT seconds it stops waiting and a condition of type SB-EXT:TIMEOUT
+is signaled. The command itself will continue to run until it is finished.
+Be careful, the shell command will hang StumpWM until it returns or timeouts."
   (if collect-output-p
-      (run-prog-collect-output *shell-program* "-c" cmd)
+      (sb-ext:with-timeout timeout
+        (run-prog-collect-output *shell-program* "-c" cmd))
       (run-prog *shell-program* :args (list "-c" cmd) :wait nil)))
 
 (defcommand run-shell-command-and-show-output (cmd &optional (timeout 5)) ((:shell "/bin/sh -c "))

--- a/user.lisp
+++ b/user.lisp
@@ -167,9 +167,15 @@ such a case, kill the shell command to resume StumpWM."
       (run-prog-collect-output *shell-program* "-c" cmd)
       (run-prog *shell-program* :args (list "-c" cmd) :wait nil)))
 
-(defcommand run-shell-command-and-show-output (cmd) ((:shell "/bin/sh -c "))
-  "Call run-shell-command, collect the output and show as message"
-  (message (run-shell-command cmd t)))
+(defcommand run-shell-command-and-show-output (cmd &optional (timeout 5)) ((:shell "/bin/sh -c "))
+  "Call RUN-SHELL-COMMAND, collect the output and show as message.
+After TIMEOUT seconds we stop waiting for the output and show a warning.
+Even then, CMD will continue to run until it is finished."
+  (handler-case
+      (sb-ext:with-timeout timeout
+        (message (run-shell-command cmd t)))
+    (sb-ext:timeout (e)
+      (message (format nil "~e Command \"~a\" did not finish within ~s seconds.~%Warning: The programm was not stopped by this timeout. It might still be running." e cmd timeout)))))
 
 (defcommand-alias exec run-shell-command)
 


### PR DESCRIPTION
This branch changed so that RUN-SHELL-COMMAND has now proper timeout handling, and translates sbcl's SB-EXT:TIMEOUT (which is just a SERIOUS-CONDITION) into our own new SHELL-TIMEOUT which is a proper ERROR and as such is also handled by STUMPWM:EVAL-COMMAND.

EXEC&SHOW is still there but doesn't need any error handling anymore. This is much nicer.


Note:
Right now with SBCL 2.0.4 the error that StumpWM will display looks like this:
```
Timeout occurred.
Command "sleep 6; echo foo" did not finish within 5 seconds.
Warning: The command was not stopped by this timeout. It might still be running.
```
But there is a patch by me already merged into SBCL that will be in SBCL 2.0.5 to make the error by SB-EXT:WITH-TIMEOUT a bit nicer by default, and this will lead to this display:
```
Timeout occurred after 5 seconds.
Command "sleep 6; echo foo" did not finish within 5 seconds.
Warning: The command was not stopped by this timeout. It might still be running.
```
see https://sourceforge.net/p/sbcl/sbcl/ci/5eaddcd6d8777b0bc5387a0c6f5382b03de3e6d5/